### PR TITLE
#170932632 user advertiser update announcement endpoint ch3

### DIFF
--- a/server/config/tables.js
+++ b/server/config/tables.js
@@ -41,8 +41,8 @@ const create = () => {
       picture varchar NULL,
       title varchar NOT NULL,
       text varchar NOT NULL,
-      start_date timestamptz NOT NULL,
-      end_date timestamptz NOT NULL,
+      start_date varchar NOT NULL,
+      end_date varchar NOT NULL,
       status varchar NOT NULL,
       owner int REFERENCES users(id) ON DELETE CASCADE,
       createdon timestamptz NOT NULL

--- a/server/controllers/advertiserCh3.js
+++ b/server/controllers/advertiserCh3.js
@@ -1,0 +1,57 @@
+/* eslint-disable object-shorthand */
+/* eslint-disable no-shadow */
+import moment from 'moment';
+import jwt from 'jsonwebtoken';
+import validation from '../middleware/validation';
+import messages from '../utils/messages';
+import utils from '../utils/utils';
+import codes from '../utils/codes';
+import queries from '../utils/queries';
+
+// eslint-disable-next-line func-names
+const createAnnouncement = async (req, res) => {
+  // Joi Validation
+  const { error } = validation.validateCreateAnnouncement(req.body);
+  if (error) {
+    return utils.returnError(res, codes.statusCodes.badRequest, error.details[0].message);
+  }
+  // Retrieve token info
+  const token = req.headers.authorization.split(' ')[1];
+  const decoded = jwt.verify(token, process.env.JWT_KEY);
+  req.userData = decoded;
+  const data = {
+    title: req.body.title.trim(),
+    description: req.body.description.trim(),
+    startdate: moment(req.body.startdate.trim(), 'MM-DD-YYYY HH:mm').format('x'),
+    enddate: moment(req.body.enddate.trim(), 'MM-DD-YYYY HH:mm').format('x'),
+    status: 'pending',
+    owner: req.userData.id,
+    createdon: moment().format('LLLL'),
+  };
+  // Check if dates are valid
+  const areDatesValid = utils.checkDates(data.startdate, data.enddate);
+  if (!areDatesValid) {
+    return utils.returnError(res, codes.statusCodes.badRequest, messages.expiredDates);
+  }
+  // Check if user has permission to create announcements
+  const hasPermission = await queries.canCreateUpdateAnnouncements(data.owner);
+  if (!hasPermission) {
+    return utils.returnError(res, codes.statusCodes.unauthorized, messages.blacklisted);
+  }
+  // Check if announcement exists already (title and creator)
+  const announcement = await queries.doesAnnouncementExists(data.title, data.owner);
+  if (announcement) {
+    return utils.returnError(res, codes.statusCodes.badRequest, messages.announcementExists);
+  }
+  // Save announcement
+  const newAnnouncement = await queries.saveAnnouncement(data);
+  return res.status(201).json({
+    status: 201,
+    message: messages.announcementCreated,
+    data: newAnnouncement.rows[0],
+  });
+};
+
+export default {
+  createAnnouncement,
+};

--- a/server/controllers/advertiserCh3.js
+++ b/server/controllers/advertiserCh3.js
@@ -7,6 +7,7 @@ import messages from '../utils/messages';
 import utils from '../utils/utils';
 import codes from '../utils/codes';
 import queries from '../utils/queries';
+import auth from '../middleware/auth';
 
 // eslint-disable-next-line func-names
 const createAnnouncement = async (req, res) => {
@@ -16,16 +17,14 @@ const createAnnouncement = async (req, res) => {
     return utils.returnError(res, codes.statusCodes.badRequest, error.details[0].message);
   }
   // Retrieve token info
-  const token = req.headers.authorization.split(' ')[1];
-  const decoded = jwt.verify(token, process.env.JWT_KEY);
-  req.userData = decoded;
+  const myToken = await auth.myToken(req);
   const data = {
     title: req.body.title.trim(),
     description: req.body.description.trim(),
     startdate: moment(req.body.startdate.trim(), 'MM-DD-YYYY HH:mm').format('x'),
     enddate: moment(req.body.enddate.trim(), 'MM-DD-YYYY HH:mm').format('x'),
     status: 'pending',
-    owner: req.userData.id,
+    owner: myToken.id,
     createdon: moment().format('LLLL'),
   };
   // Check if dates are valid
@@ -59,15 +58,13 @@ const updateAnnouncement = async (req, res) => {
     return utils.returnError(res, codes.statusCodes.badRequest, error.details[0].message);
   }
   // Retrieve token info
-  const token = req.headers.authorization.split(' ')[1];
-  const decoded = jwt.verify(token, process.env.JWT_KEY);
-  req.userData = decoded;
+  const myToken = await auth.myToken(req);
   // Generate new id
   const data = {
     description: req.body.description.trim(),
     startdate: moment(req.body.startdate.trim(), 'MM-DD-YYYY HH:mm').format('x'),
     enddate: moment(req.body.enddate.trim(), 'MM-DD-YYYY HH:mm').format('x'),
-    owner: req.userData.id,
+    owner: myToken.id,
     announcementId: req.params.id,
   };
   // Check if dates are valid

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,12 @@
+import jwt from 'jsonwebtoken';
+
+const myToken = (req) => {
+  const token = req.headers.authorization.split(' ')[1];
+  const decoded = jwt.verify(token, process.env.JWT_KEY);
+  req.userData = decoded;
+  return req.userData;
+};
+
+export default {
+  myToken,
+};

--- a/server/routes/advertiserCh3.js
+++ b/server/routes/advertiserCh3.js
@@ -5,5 +5,6 @@ import authenticate from '../middleware/authenticate';
 const router = express.Router();
 
 router.post('/announcement', authenticate, controller.createAnnouncement);
+router.patch('/announcement/:id', authenticate, controller.updateAnnouncement);
 
 export default router;

--- a/server/routes/advertiserCh3.js
+++ b/server/routes/advertiserCh3.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import controller from '../controllers/advertiserCh3';
+import authenticate from '../middleware/authenticate';
+
+const router = express.Router();
+
+router.post('/announcement', authenticate, controller.createAnnouncement);
+
+export default router;

--- a/server/routes/route.js
+++ b/server/routes/route.js
@@ -12,6 +12,6 @@ router.use('/api/v1/advertiser', advertiserRoutes);
 router.use('/api/v1/admin', adminrRoutes);
 // Challenge 3 routes
 router.use('/api/v2/auth', user);
-router.use('/api/v2/auth', advertiser);
+router.use('/api/v2/advertiser', advertiser);
 
 export default router;

--- a/server/routes/route.js
+++ b/server/routes/route.js
@@ -3,6 +3,7 @@ import userRoutes from './users';
 import advertiserRoutes from './advertiser';
 import adminrRoutes from './admin';
 import user from './usersCh3';
+import advertiser from './advertiserCh3';
 
 const router = express.Router();
 
@@ -11,5 +12,6 @@ router.use('/api/v1/advertiser', advertiserRoutes);
 router.use('/api/v1/admin', adminrRoutes);
 // Challenge 3 routes
 router.use('/api/v2/auth', user);
+router.use('/api/v2/auth', advertiser);
 
 export default router;

--- a/server/tests/advertiserCh3.js
+++ b/server/tests/advertiserCh3.js
@@ -1,0 +1,223 @@
+/* eslint-disable no-undef */
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+import messages from '../utils/messages';
+
+const { expect } = chai;
+let token = '';
+chai.use(chaiHttp);
+chai.should();
+
+describe('Advertiser V2', () => {
+  it('Should return status code 401', (done) => {
+    chai.request(app)
+      .post('/api/v2/advertiser/announcement')
+      .send({
+        title: '70% discount on all products',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '02-23-2020 12:15',
+        enddate: '02-25-2020 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(401);
+        expect(error);
+        expect(error).to.equal(messages.noToken);
+        done();
+      });
+  });
+  it('Should return status code 201', (done) => {
+    chai.request(app)
+      .post('/api/v2/auth/signup')
+      .send({
+        firstname: 'John',
+        lastname: 'Mugabo',
+        email: 'john@gmail.com',
+        phone: '+250787770000',
+        address: 'Kigali, Rwanda',
+        password: 'mugabojohn',
+        confirmpassword: 'mugabojohn',
+      })
+      .end((err, res) => {
+        const { status, message } = res.body;
+        expect(status);
+        expect(status).to.equal(201);
+        expect(message);
+        expect(message).to.equal(messages.successfulSignup);
+        done();
+      });
+  });
+  it('Should return status code 200', (done) => {
+    chai.request(app)
+      .post('/api/v2/auth/signin')
+      .send({
+        email: 'john@gmail.com',
+        password: 'mugabojohn',
+      })
+      .end((err, res) => {
+        const { status, message, data } = res.body;
+        token = data.token;
+        expect(status);
+        expect(status).to.equal(200);
+        expect(message);
+        expect(message).to.equal(messages.successfulLogin);
+        expect(data).to.have.property('token');
+        done();
+      });
+  });
+  it('Should return status code 201', (done) => {
+    chai.request(app)
+      .post('/api/v2/advertiser/announcement')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: '70% discount on all products',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '02-23-2020 12:15',
+        enddate: '02-25-2020 11:59',
+      })
+      .end((err, res) => {
+        const {
+          id,
+          title,
+          description,
+          startdate,
+          enddate,
+          status,
+          owner,
+          createdon,
+        } = res.body.data;
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal(201);
+        expect(res.body).to.have.property('message');
+        expect(res.body.message).to.equal(messages.announcementCreated);
+        expect(res.body).to.have.property('data');
+        expect(id);
+        expect(title);
+        expect(description);
+        expect(startdate);
+        expect(enddate);
+        expect(status);
+        expect(status).to.equal('pending');
+        expect(owner);
+        expect(owner).to.be.a('number');
+        expect(createdon);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .post('/api/v2/advertiser/announcement')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: '70% discount on all products',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '02-23-2020 12:15',
+        enddate: '02-25-2020 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.announcementExists);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .post('/api/v2/advertiser/announcement')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: '',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '02-23-2020 12:15',
+        enddate: '02-25-2020 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.announcementEmptyTitle);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .post('/api/v2/advertiser/announcement')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'none',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '02-23-2020 12:15',
+        enddate: '02-25-2020 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.announcementInvalidTitle);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .post('/api/v2/advertiser/announcement')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: '70% discount on all products',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '01-01-2020 12:15',
+        enddate: '02-12-2019 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.expiredDates);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .post('/api/v2/advertiser/announcement')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: '70% discount on all products',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '01-01-2030 12:15',
+        enddate: '01-01-2029 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.expiredDates);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .post('/api/v2/advertiser/announcement')
+      .set('Authorization', 'Bearer invalidkey')
+      .send({
+        title: '70% discount on all products',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '03-29-2020 12:15',
+        enddate: '05-25-2020 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.malformedToken);
+        done();
+      });
+  });
+});

--- a/server/tests/advertiserCh3.js
+++ b/server/tests/advertiserCh3.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /* eslint-disable no-undef */
 import chai from 'chai';
 import chaiHttp from 'chai-http';
@@ -6,6 +7,7 @@ import messages from '../utils/messages';
 
 const { expect } = chai;
 let token = '';
+let announcementId = '';
 chai.use(chaiHttp);
 chai.should();
 
@@ -207,6 +209,154 @@ describe('Advertiser V2', () => {
       .set('Authorization', 'Bearer invalidkey')
       .send({
         title: '70% discount on all products',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '03-29-2020 12:15',
+        enddate: '05-25-2020 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.malformedToken);
+        done();
+      });
+  });
+  // Update announcement
+  it('Should return status code 201', (done) => {
+    chai.request(app)
+      .post('/api/v2/advertiser/announcement')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: '90% discount on all products',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '02-23-2020 12:15',
+        enddate: '02-25-2020 11:59',
+      })
+      .end((err, res) => {
+        announcementId = res.body.data.id;
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal(201);
+        expect(res.body).to.have.property('message');
+        expect(res.body.message).to.equal(messages.announcementCreated);
+        expect(res.body).to.have.property('data');
+        done();
+      });
+  });
+  it('Should return status code 401', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/advertiser/announcement/${announcementId}`)
+      .send({
+        title: '70% discount on all products',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '02-23-2020 12:15',
+        enddate: '02-25-2020 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(401);
+        expect(error);
+        expect(error).to.equal(messages.noToken);
+        done();
+      });
+  });
+  it('Should return status code 200', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/advertiser/announcement/${announcementId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        description: "February 2030 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '02-23-2030 12:15',
+        enddate: '02-25-2030 11:59',
+      })
+      .end((err, res) => {
+        const {
+          id,
+          title,
+          text,
+          start_date,
+          end_date,
+          status,
+          owner,
+          createdon,
+        } = res.body.data;
+        expect(res.body).to.have.property('status');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.have.property('message');
+        expect(res.body.message).to.equal(messages.announcementUpdatetd);
+        expect(res.body).to.have.property('data');
+        expect(id);
+        expect(title);
+        expect(text);
+        expect(start_date);
+        expect(end_date);
+        expect(status);
+        expect(owner);
+        expect(owner).to.be.a('number');
+        expect(createdon);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/advertiser/announcement/${announcementId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        description: '',
+        startdate: '02-23-2020 12:15',
+        enddate: '02-25-2020 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.announcementEmptyDesc);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/advertiser/announcement/${announcementId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        description: 'none',
+        startdate: '02-23-2020 12:15',
+        enddate: '02-25-2020 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.announcementInvalidDesc);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/advertiser/announcement/${announcementId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '01-01-2020 12:15',
+        enddate: '02-12-2019 11:59',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.expiredDates);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/advertiser/announcement/${announcementId}`)
+      .set('Authorization', 'Bearer invalidkey')
+      .send({
         description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
         startdate: '03-29-2020 12:15',
         enddate: '05-25-2020 11:59',

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -25,7 +25,38 @@ const signupUser = async (data) => {
   return user;
 };
 
+const canCreateUpdateAnnouncements = async (id) => {
+  const user = await pool.query('SELECT status FROM users WHERE id=$1', [id]);
+  return user.rows[0].status;
+};
+
+const doesAnnouncementExists = async (title, owner) => {
+  const announcement = await pool.query('SELECT * FROM announcements WHERE title=$1 and owner=$2', [title, owner]);
+  if (announcement.rows.length !== 0) {
+    return true;
+  }
+  return false;
+};
+
+const saveAnnouncement = async (data) => {
+  const announcement = await pool.query('INSERT INTO announcements(title,text,start_date,end_date,status,owner,createdon) VALUES($1,$2,$3,$4,$5,$6,$7) RETURNING*',
+    [
+      data.title,
+      data.description,
+      data.startdate,
+      data.enddate,
+      data.status,
+      data.owner,
+      data.createdon,
+
+    ]);
+  return announcement;
+};
+
 export default {
   isUserRegistered,
   signupUser,
+  canCreateUpdateAnnouncements,
+  doesAnnouncementExists,
+  saveAnnouncement,
 };

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -53,10 +53,32 @@ const saveAnnouncement = async (data) => {
   return announcement;
 };
 
+const fetchMyAnnouncement = async (id, owner) => {
+  const announcement = await pool.query('SELECT * FROM announcements WHERE id=$1 and owner=$2', [id, owner]);
+  if (announcement.rows.length !== 0) {
+    return true;
+  }
+  return false;
+};
+
+const updateAnnouncement = async (data) => {
+  const announcement = await pool.query('UPDATE announcements SET text=$1,start_date=$2,end_date=$3 WHERE id=$4 and owner=$5 RETURNING*',
+    [
+      data.description,
+      data.startdate,
+      data.enddate,
+      data.announcementId,
+      data.owner,
+    ]);
+  return announcement;
+};
+
 export default {
   isUserRegistered,
   signupUser,
   canCreateUpdateAnnouncements,
   doesAnnouncementExists,
   saveAnnouncement,
+  fetchMyAnnouncement,
+  updateAnnouncement,
 };

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -48,7 +48,6 @@ const saveAnnouncement = async (data) => {
       data.status,
       data.owner,
       data.createdon,
-
     ]);
   return announcement;
 };


### PR DESCRIPTION
#### What does this PR do?
Add advertiser update announcement functionality with database
#### Description of Task to be completed?
#### How should this be manually tested?

- Clone this repo
- run `cd announceIT && npm run test`

#### Any background context you want to provide?
An advertiser will be able to update only the announcements he/she has created
#### What are the relevant pivotal tracker stories?
#170932632
#### Screenshots (if appropriate)
#### Questions: