### PR TITLE
#170932628 user admin view announcements from all users endpoint ch3

### DIFF
--- a/server/controllers/adminCh3.js
+++ b/server/controllers/adminCh3.js
@@ -1,0 +1,20 @@
+import messages from '../utils/messages';
+import utils from '../utils/utils';
+import codes from '../utils/codes';
+import queries from '../utils/queries';
+
+const viewAllUsersAnnouncements = async (req, res) => {
+  // Retrieve announcements
+  const announcements = await queries.fetchAllUsersAnnouncements();
+  if (announcements.rows.length === 0) {
+    return utils.returnError(res, codes.statusCodes.notFound, messages.announcementDoesntExist);
+  }
+  return res.status(200).json({
+    status: 200,
+    data: announcements.rows,
+  });
+};
+
+export default {
+  viewAllUsersAnnouncements,
+};

--- a/server/routes/adminCh3.js
+++ b/server/routes/adminCh3.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import controller from '../controllers/adminCh3';
+import authenticate from '../middleware/authenticate';
+import isUserAdmin from '../middleware/isUserAdmin';
+
+const router = express.Router();
+
+router.get('/announcements', authenticate, isUserAdmin, controller.viewAllUsersAnnouncements);
+
+export default router;

--- a/server/routes/route.js
+++ b/server/routes/route.js
@@ -4,6 +4,7 @@ import advertiserRoutes from './advertiser';
 import adminrRoutes from './admin';
 import user from './usersCh3';
 import advertiser from './advertiserCh3';
+import admin from './adminCh3';
 
 const router = express.Router();
 
@@ -13,5 +14,6 @@ router.use('/api/v1/admin', adminrRoutes);
 // Challenge 3 routes
 router.use('/api/v2/auth', user);
 router.use('/api/v2/advertiser', advertiser);
+router.use('/api/v2/admin', admin);
 
 export default router;

--- a/server/tests/adminCh3.js
+++ b/server/tests/adminCh3.js
@@ -1,0 +1,173 @@
+/* eslint-disable camelcase */
+/* eslint-disable no-undef */
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+import messages from '../utils/messages';
+
+const { expect } = chai;
+let token = '';
+let admintoken = '';
+let advertiserId = '';
+chai.use(chaiHttp);
+chai.should();
+
+describe('Admin V2', () => {
+  it('Should return status code 201', (done) => {
+    chai.request(app)
+      .post('/api/v2/auth/signup')
+      .send({
+        firstname: 'John',
+        lastname: 'Mugabo',
+        email: 'johnnymu@gmail.com',
+        phone: '+250787770000',
+        address: 'Kigali, Rwanda',
+        password: 'mugabojohn',
+        confirmpassword: 'mugabojohn',
+        isadmin: true,
+      })
+      .end((err, res) => {
+        const { status, message } = res.body;
+        expect(status);
+        expect(status).to.equal(201);
+        expect(message);
+        expect(message).to.equal(messages.successfulSignup);
+        done();
+      });
+  });
+  it('Should return status code 200', (done) => {
+    chai.request(app)
+      .post('/api/v2/auth/signin')
+      .send({
+        email: 'johnnymu@gmail.com',
+        password: 'mugabojohn',
+      })
+      .end((err, res) => {
+        const { status, message } = res.body;
+        admintoken = res.body.data.token;
+        expect(status);
+        expect(status).to.equal(200);
+        expect(message);
+        expect(message).to.equal(messages.successfulLogin);
+        expect(res.body.data).to.have.property('token');
+        expect(res.body.data).to.have.property('isadmin');
+        expect(res.body.data.isadmin).to.equal(true);
+        done();
+      });
+  });
+  it('Should return status code 404', (done) => {
+    chai.request(app)
+      .get('/api/v2/admin/announcements')
+      .set('Authorization', `Bearer ${admintoken}`)
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(404);
+        expect(error);
+        expect(error).to.equal(messages.announcementDoesntExist);
+        done();
+      });
+  });
+  it('Should return status code 201', (done) => {
+    chai.request(app)
+      .post('/api/v2/auth/signup')
+      .send({
+        firstname: 'John',
+        lastname: 'Mugabo',
+        email: 'jane@gmail.com',
+        phone: '+250787770000',
+        address: 'Kigali, Rwanda',
+        password: 'mugabojohn',
+        confirmpassword: 'mugabojohn',
+      })
+      .end((err, res) => {
+        const { status, message } = res.body;
+        expect(status);
+        expect(status).to.equal(201);
+        expect(message);
+        expect(message).to.equal(messages.successfulSignup);
+        done();
+      });
+  });
+  it('Should return status code 200', (done) => {
+    chai.request(app)
+      .post('/api/v2/auth/signin')
+      .send({
+        email: 'jane@gmail.com',
+        password: 'mugabojohn',
+      })
+      .end((err, res) => {
+        const { status, message } = res.body;
+        token = res.body.data.token;
+        advertiserId = res.body.data.id;
+        expect(status);
+        expect(status).to.equal(200);
+        expect(message);
+        expect(message).to.equal(messages.successfulLogin);
+        expect(res.body.data).to.have.property('token');
+        done();
+      });
+  });
+  it('Should return status code 201', (done) => {
+    chai.request(app)
+      .post('/api/v2/advertiser/announcement')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: '55% discount on all products',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '02-23-2020 12:15',
+        enddate: '02-25-2020 11:59',
+      })
+      .end((err, res) => {
+        const { status, message } = res.body;
+        expect(status);
+        expect(status).to.equal(201);
+        expect(message);
+        expect(message).to.equal(messages.announcementCreated);
+        done();
+      });
+  });
+  it('Should return status code 401', (done) => {
+    chai.request(app)
+      .get('/api/v2/admin/announcements')
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(401);
+        expect(error);
+        expect(error).to.equal(messages.noToken);
+        done();
+      });
+  });
+  it('Should return status code 200', (done) => {
+    chai.request(app)
+      .get('/api/v2/admin/announcements')
+      .set('Authorization', `Bearer ${admintoken}`)
+      .end((err, res) => {
+        const {
+          id,
+          title,
+          text,
+          start_date,
+          end_date,
+          status,
+          owner,
+          createdon,
+        } = res.body.data[0];
+        expect(res.body).to.have.property('status');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.have.property('data');
+        expect(id);
+        expect(id).to.be.a('number');
+        expect(title);
+        expect(text);
+        expect(start_date);
+        expect(end_date);
+        expect(status);
+        expect(owner);
+        expect(owner).to.be.a('number');
+        expect(createdon);
+        done();
+      });
+  });
+});

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -79,6 +79,11 @@ const retrieveAnnouncement = async (id) => {
   return announcement.rows;
 };
 
+const fetchAllUsersAnnouncements = async () => {
+  const announcements = await pool.query('SELECT * FROM announcements');
+  return announcements;
+};
+
 export default {
   isUserRegistered,
   signupUser,
@@ -87,4 +92,5 @@ export default {
   saveAnnouncement,
   fetchMyAnnouncement,
   updateAnnouncement,
+  fetchAllUsersAnnouncements,
 };

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -74,8 +74,6 @@ const updateAnnouncement = async (data) => {
 
 const retrieveAnnouncement = async (id) => {
   const announcement = await pool.query('SELECT * FROM announcements WHERE id=$1', [id]);
-  console.log(announcement.rows);
-  console.log('=====================');
   return announcement.rows;
 };
 


### PR DESCRIPTION
#### What does this PR do?
Add admin view all announcements from all users functionality with database
#### Description of Task to be completed?
#### How should this be manually tested?

- Clone this repo
- run `cd announceIT && npm run test`

#### Any background context you want to provide?
Announcements should be ordered by last created first
#### What are the relevant pivotal tracker stories?
#170932628
#### Screenshots (if appropriate)
#### Questions: