### PR TITLE
#170932623 Admin change announcement status with database

### DIFF
--- a/server/controllers/adminCh3.js
+++ b/server/controllers/adminCh3.js
@@ -2,6 +2,7 @@ import messages from '../utils/messages';
 import utils from '../utils/utils';
 import codes from '../utils/codes';
 import queries from '../utils/queries';
+import validation from '../middleware/validation';
 
 const viewAllUsersAnnouncements = async (req, res) => {
   // Retrieve announcements
@@ -31,7 +32,30 @@ const deleteAnnouncement = async (req, res) => {
   });
 };
 
+const changeAnnouncementStatus = async (req, res) => {
+  // Joi Validation
+  const { error } = validation.validateState(req.body);
+  if (error) {
+    return utils.returnError(res, codes.statusCodes.badRequest, error.details[0].message);
+  }
+  const { announcementId } = req.params;
+  const { announcementStatus } = req.body;
+  // Check and retrieve announcement
+  const announcement = await queries.checkAnnouncement(parseInt(announcementId, 10));
+  if (announcement.rows.length === 0) {
+    return utils.returnError(res, codes.statusCodes.notFound, messages.announcementDoesntExist);
+  }
+  // Update announcement status
+  const updateAnnouncement = await queries.updateAnnouncementStatus(announcementStatus, announcementId);
+  return res.status(200).json({
+    status: 200,
+    message: messages.announcementUpdatetd,
+    data: updateAnnouncement.rows[0],
+  });
+};
+
 export default {
   viewAllUsersAnnouncements,
   deleteAnnouncement,
+  changeAnnouncementStatus,
 };

--- a/server/routes/adminCh3.js
+++ b/server/routes/adminCh3.js
@@ -8,5 +8,6 @@ const router = express.Router();
 
 router.get('/announcements', authenticate, isUserAdmin, controller.viewAllUsersAnnouncements);
 router.delete('/announcements/:announcementId', authenticate, isUserAdmin, checkId, controller.deleteAnnouncement);
+router.patch('/announcements/:announcementId', authenticate, isUserAdmin, checkId, controller.changeAnnouncementStatus);
 
 export default router;

--- a/server/tests/adminCh3.js
+++ b/server/tests/adminCh3.js
@@ -171,7 +171,7 @@ describe('Admin V2', () => {
         expect(owner);
         expect(owner).to.be.a('number');
         expect(createdon);
-      done();
+        done();
       });
   });
   it('Should return status code 200', (done) => {
@@ -192,6 +192,76 @@ describe('Admin V2', () => {
     chai.request(app)
       .delete('/api/v2/admin/announcements/1000')
       .set('Authorization', `Bearer ${admintoken}`)
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(404);
+        expect(error);
+        expect(error).to.equal(messages.announcementDoesntExist);
+        done();
+      });
+  });
+  // Change announcement status
+  it('Should return status code 201', (done) => {
+    chai.request(app)
+      .post('/api/v2/advertiser/announcement')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: '55% discount on all products',
+        description: "January 2020 promo. Discount of up to 50% on all our products. Come buy all house items, we've got you covered! Valid only from jan 1st to jan 31st",
+        startdate: '02-23-2020 12:15',
+        enddate: '02-25-2020 11:59',
+      })
+      .end((err, res) => {
+        announcementId = res.body.data.id;
+        const { status, message } = res.body;
+        expect(status);
+        expect(status).to.equal(201);
+        expect(message);
+        expect(message).to.equal(messages.announcementCreated);
+        done();
+      });
+  });
+  it('Should return status code 200', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/admin/announcements/${announcementId}`)
+      .set('Authorization', `Bearer ${admintoken}`)
+      .send({
+        announcementStatus: 'accepted',
+      })
+      .end((err, res) => {
+        const { status, message, data } = res.body;
+        expect(status);
+        expect(status).to.equal(200);
+        expect(message);
+        expect(message).to.equal(messages.announcementUpdatetd);
+        expect(data);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/admin/announcements/${announcementId}`)
+      .set('Authorization', `Bearer ${admintoken}`)
+      .send({
+        announcementStatus: 'an invalid status',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.invalidAnnouncementStatus);
+        done();
+      });
+  });
+  it('Should return status code 404', (done) => {
+    chai.request(app)
+      .patch('/api/v2/admin/announcements/1000')
+      .set('Authorization', `Bearer ${admintoken}`)
+      .send({
+        announcementStatus: 'accepted',
+      })
       .end((err, res) => {
         const { status, error } = res.body;
         expect(status);

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -98,6 +98,15 @@ const fetchAllUsersAnnouncements = async () => {
   return announcements;
 };
 
+const updateAnnouncementStatus = async (announcementStatus, announcementId) => {
+  const announcement = await pool.query('UPDATE announcements SET status=$1 WHERE id=$2 RETURNING*',
+    [
+      announcementStatus,
+      announcementId,
+    ]);
+  return announcement;
+};
+
 export default {
   isUserRegistered,
   signupUser,
@@ -111,4 +120,5 @@ export default {
   retrieveAnnouncement,
   checkAnnouncement,
   dropAnnouncement,
+  updateAnnouncementStatus,
 };


### PR DESCRIPTION
#### What does this PR do?
Add admin change announcement status functionality with database
#### Description of Task to be completed?
#### How should this be manually tested?

- Clone this repo
- run `cd announceIT && npm run test`

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#170932623
#### Screenshots (if appropriate)
#### Questions: