### PR TITLE
#170932630 Add advertiser view announcements by state

### DIFF
--- a/server/controllers/advertiserCh3.js
+++ b/server/controllers/advertiserCh3.js
@@ -124,9 +124,27 @@ const viewSpecificAnnouncement = async (req, res) => {
   });
 };
 
+const viewAnnouncementsOfState = async (req, res) => {
+  const { announcementStatus } = req.params;
+  // Check and retrieve announcement
+  const announcements = await queries.fetchAllMyAnnouncements(req.userData.id);
+  if (announcements.rows.length === 0) {
+    return utils.returnError(res, codes.statusCodes.notFound, messages.announcementDoesntExist);
+  }
+  const sortedAnnouncements = announcements.rows.filter(({ status }) => status === announcementStatus);
+  if (sortedAnnouncements.length === 0) {
+    return utils.returnError(res, codes.statusCodes.notFound, messages.announcementDoesntExist);
+  }
+  return res.status(200).json({
+    status: 200,
+    data: sortedAnnouncements,
+  });
+};
+
 export default {
   createAnnouncement,
   updateAnnouncement,
   viewAllAnnouncements,
   viewSpecificAnnouncement,
+  viewAnnouncementsOfState,
 };

--- a/server/routes/advertiserCh3.js
+++ b/server/routes/advertiserCh3.js
@@ -2,6 +2,7 @@ import express from 'express';
 import controller from '../controllers/advertiserCh3';
 import authenticate from '../middleware/authenticate';
 import checkId from '../middleware/isInteger';
+import checkState from '../middleware/isStateValid';
 
 const router = express.Router();
 
@@ -9,5 +10,6 @@ router.post('/announcement', authenticate, controller.createAnnouncement);
 router.patch('/announcement/:id', authenticate, controller.updateAnnouncement);
 router.get('/announcements', authenticate, controller.viewAllAnnouncements);
 router.get('/announcement/:announcementId', checkId, authenticate, controller.viewSpecificAnnouncement);
+router.get('/announcements/:announcementStatus', checkState, authenticate, controller.viewAnnouncementsOfState);
 
 export default router;

--- a/server/tests/advertiserCh3.js
+++ b/server/tests/advertiserCh3.js
@@ -447,7 +447,7 @@ describe('Advertiser V2', () => {
         expect(owner).to.be.a('number');
         expect(createdon);
         done();
-    });
+      });
   });
   it('Should return status code 400', (done) => {
     chai.request(app)
@@ -522,6 +522,51 @@ describe('Advertiser V2', () => {
         expect(owner);
         expect(owner).to.be.a('number');
         expect(createdon);
+        done();
+      });
+  });
+  // View announcements by state
+  it('Should return status code 200', (done) => {
+    chai.request(app)
+      .get('/api/v2/advertiser/announcements/pending')
+      .set('Authorization', `Bearer ${token}`)
+      .end((err, res) => {
+        const {
+          id,
+          title,
+          text,
+          start_date,
+          end_date,
+          status,
+          owner,
+          createdon,
+        } = res.body.data[0];
+        expect(res.body).to.have.property('status');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.have.property('data');
+        expect(id);
+        expect(id).to.be.a('number');
+        expect(title);
+        expect(text);
+        expect(start_date);
+        expect(end_date);
+        expect(status);
+        expect(owner);
+        expect(owner).to.be.a('number');
+        expect(createdon);
+        done();
+      });
+  });
+  it('Should return status code 404', (done) => {
+    chai.request(app)
+      .get('/api/v2/advertiser/announcements/declined')
+      .set('Authorization', `Bearer ${token}`)
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(404);
+        expect(error);
+        expect(error).to.equal(messages.announcementDoesntExist);
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
Add advertiser view announcements by state functionality with database
#### Description of Task to be completed?
#### How should this be manually tested?

- Clone this repo
- run `cd announceIT && npm run test`

#### Any background context you want to provide?
This is where the advertiser will be able to filter through his/her announcements by the following states: pending, accepted, declined, active, and deactivated
#### What are the relevant pivotal tracker stories?
#170932630
#### Screenshots (if appropriate)
#### Questions: