### PR TITLE
#171010664 Admin blacklist or whitelist user

### DIFF
--- a/server/routes/adminCh3.js
+++ b/server/routes/adminCh3.js
@@ -3,11 +3,13 @@ import controller from '../controllers/adminCh3';
 import authenticate from '../middleware/authenticate';
 import isUserAdmin from '../middleware/isUserAdmin';
 import checkId from '../middleware/isInteger';
+import checkUserId from '../middleware/checkUserId';
 
 const router = express.Router();
 
 router.get('/announcements', authenticate, isUserAdmin, controller.viewAllUsersAnnouncements);
 router.delete('/announcements/:announcementId', authenticate, isUserAdmin, checkId, controller.deleteAnnouncement);
 router.patch('/announcements/:announcementId', authenticate, isUserAdmin, checkId, controller.changeAnnouncementStatus);
+router.patch('/users/:id', authenticate, isUserAdmin, checkUserId.checkUserId, controller.changeUserStatus);
 
 export default router;

--- a/server/tests/adminCh3.js
+++ b/server/tests/adminCh3.js
@@ -271,4 +271,140 @@ describe('Admin V2', () => {
         done();
       });
   });
+  // Change user status
+  it('Should return status code 201', (done) => {
+    chai.request(app)
+      .post('/api/v2/auth/signup')
+      .send({
+        firstname: 'John',
+        lastname: 'Mugabo',
+        email: 'janet@gmail.com',
+        phone: '+250787770000',
+        address: 'Kigali, Rwanda',
+        password: 'mugabojohn',
+        confirmpassword: 'mugabojohn',
+      })
+      .end((err, res) => {
+        const { status, message } = res.body;
+        advertiserId = res.body.data.id;
+        expect(status);
+        expect(status).to.equal(201);
+        expect(message);
+        expect(message).to.equal(messages.successfulSignup);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/admin/users/${advertiserId}`)
+      .set('Authorization', `Bearer ${admintoken}`)
+      .send({
+        userStatus: 'another status',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.invalidUserStatus);
+        done();
+      });
+  });
+  it('Should return status code 404', (done) => {
+    chai.request(app)
+      .patch('/api/v2/admin/users/199')
+      .set('Authorization', `Bearer ${admintoken}`)
+      .send({
+        userStatus: 'active',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(404);
+        expect(error);
+        expect(error).to.equal(messages.userDoesntExist);
+        done();
+      });
+  });
+  it('Should return status code 409', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/admin/users/${advertiserId}`)
+      .set('Authorization', `Bearer ${admintoken}`)
+      .send({
+        userStatus: 'active',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(409);
+        expect(error);
+        expect(error).to.equal(messages.userIsActive);
+        done();
+      });
+  });
+  it('Should return status code 200', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/admin/users/${advertiserId}`)
+      .set('Authorization', `Bearer ${admintoken}`)
+      .send({
+        userStatus: 'blacklisted',
+      })
+      .end((err, res) => {
+        const { status, message, data } = res.body;
+        expect(status);
+        expect(status).to.equal(200);
+        expect(message);
+        expect(message).to.equal(messages.userStatusUpdateSuccessful);
+        expect(data);
+        done();
+      });
+  });
+  it('Should return status code 409', (done) => {
+    chai.request(app)
+      .patch(`/api/v2/admin/users/${advertiserId}`)
+      .set('Authorization', `Bearer ${admintoken}`)
+      .send({
+        userStatus: 'blacklisted',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(409);
+        expect(error);
+        expect(error).to.equal(messages.userIsBlacklisted);
+        done();
+      });
+  });
+  it('Should return status code 400', (done) => {
+    chai.request(app)
+      .patch('/api/v2/admin/users/invalidId')
+      .set('Authorization', `Bearer ${admintoken}`)
+      .send({
+        userStatus: 'blacklisted',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(400);
+        expect(error);
+        expect(error).to.equal(messages.invalidUserId);
+        done();
+      });
+  });
+  it('Should return status code 401', (done) => {
+    chai.request(app)
+      .patch('/api/v2/admin/users/invalidId')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        userStatus: 'blacklisted',
+      })
+      .end((err, res) => {
+        const { status, error } = res.body;
+        expect(status);
+        expect(status).to.equal(401);
+        expect(error);
+        expect(error).to.equal(messages.noAminRights);
+        done();
+      });
+  });
 });

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -115,6 +115,20 @@ const updateAnnouncementStatus = async (announcementStatus, announcementId) => {
   return announcement;
 };
 
+const doesUserExist = async (id, role) => {
+  const user = await pool.query('SELECT * FROM users WHERE id=$1 and isadmin!=$2', [id, role]);
+  return user;
+};
+
+const updateUserStatus = async (newStatus, id) => {
+  const user = await pool.query('UPDATE users SET status=$1 WHERE id=$2 RETURNING*',
+    [
+      newStatus,
+      id,
+    ]);
+  return user;
+};
+
 export default {
   isUserRegistered,
   signupUser,
@@ -129,4 +143,6 @@ export default {
   checkAnnouncement,
   dropAnnouncement,
   updateAnnouncementStatus,
+  doesUserExist,
+  updateUserStatus,
 };


### PR DESCRIPTION
#### What does this PR do?
Add admin change user status from active to blacklisted and vice versa
#### Description of Task to be completed?
#### How should this be manually tested?

- Clone this repo
- run `cd announceIT && npm run test`

#### Any background context you want to provide?
This is where the admin will be able to block users from creating/updating announcements without deleting their accounts.
#### What are the relevant pivotal tracker stories?
#171010664
#### Screenshots (if appropriate)
#### Questions: